### PR TITLE
Serde WhiskTrackerProof to bytes

### DIFF
--- a/curdleproofs/curdleproofs/test_curdleproofs.py
+++ b/curdleproofs/curdleproofs/test_curdleproofs.py
@@ -619,10 +619,10 @@ def test_tracker_opening_proof():
         k_r_G=k_r_G, r_G=r_G, k_G=k_G, G=G, k=k, transcript=transcript_prover
     )
 
-    json_str_proof = opening_proof.to_json()
-    print("json_str_proof", json_str_proof)
+    proof_bytes = opening_proof.to_bytes()
+    print("proof_bytes", proof_bytes)
 
-    deser_proof = TrackerOpeningProof.from_json(json_str_proof)
+    deser_proof = TrackerOpeningProof.from_bytes(proof_bytes)
 
     transcript_verifier = CurdleproofsTranscript(b"whisk_opening_proof")
     assert deser_proof.verify(transcript_verifier, k_r_G, r_G, k_G)

--- a/curdleproofs/curdleproofs/whisk_interface.py
+++ b/curdleproofs/curdleproofs/whisk_interface.py
@@ -92,7 +92,7 @@ def IsValidWhiskOpeningProof(
     """
     Verify knowledge of `k` such that `tracker.k_r_G == k * tracker.r_G` and `k_commitment == k * BLS_G1_GENERATOR`.
     """
-    tracker_proof_instance = TrackerOpeningProof.from_json(tracker_proof.decode())
+    tracker_proof_instance = TrackerOpeningProof.from_bytes(tracker_proof)
 
     transcript_verifier = CurdleproofsTranscript(b"whisk_opening_proof")
     return tracker_proof_instance.verify(
@@ -118,4 +118,4 @@ def GenerateWhiskTrackerProof(
         transcript=transcript_prover,
     )
 
-    return opening_proof.to_json().encode()
+    return opening_proof.to_bytes()


### PR DESCRIPTION
TrackerOpeningProof should be serialized to a wire friendly format instead of JSON.

This PR replaces to_json and from_json with serde to a format defined as the concatenation of the compressed representation of
```
TrackerOpeningProof := A | B | s
```