### PR TITLE
Expose WhiskTracker

### DIFF
--- a/curdleproofs/curdleproofs/__init__.py
+++ b/curdleproofs/curdleproofs/__init__.py
@@ -3,6 +3,7 @@ from .whisk_interface import (
     IsValidWhiskOpeningProof,
     GenerateWhiskShuffleProof,
     GenerateWhiskTrackerProof,
+    WhiskTracker,
 )
 from .opening import TrackerOpeningProof
 from .crs import CurdleproofsCrs


### PR DESCRIPTION
Necessary to interact with Generate* APIs