### PR TITLE
Wrap M into WhiskShuffleProof

### DIFF
--- a/curdleproofs/curdleproofs/test_curdleproofs.py
+++ b/curdleproofs/curdleproofs/test_curdleproofs.py
@@ -643,8 +643,8 @@ def test_whisk_interface_shuffle_proof():
     ell = N - N_BLINDERS
     crs = generate_random_crs(ell)
     pre_trackers = generate_random_trackers(ell)
-    post_trackers, m, shuffle_proof = GenerateWhiskShuffleProof(crs, pre_trackers)
-    assert IsValidWhiskShuffleProof(crs, pre_trackers, post_trackers, m, shuffle_proof)
+    post_trackers, shuffle_proof = GenerateWhiskShuffleProof(crs, pre_trackers)
+    assert IsValidWhiskShuffleProof(crs, pre_trackers, post_trackers, shuffle_proof)
 
 
 def generate_random_k() -> Fr:


### PR DESCRIPTION
From a consumer point of view, the permutation commitment and shuffle proof and produced, transported and verified together. It adds less overhead to bundle M into the shuffle proof black box for easier implementations downstream
- Same API change in Rust impl https://github.com/asn-d6/curdleproofs/pull/11