### PR TITLE
Use PointProjective in whisk API

### DIFF
--- a/curdleproofs/curdleproofs/commitment.py
+++ b/curdleproofs/curdleproofs/commitment.py
@@ -3,7 +3,6 @@ import random
 from typing import Any, Dict, Tuple, Type, TypeVar
 from curdleproofs.crs import CurdleproofsCrs
 from curdleproofs.util import (
-    PointAffine,
     PointProjective,
     Fr,
     field_to_bytes,

--- a/curdleproofs/curdleproofs/grand_prod.py
+++ b/curdleproofs/curdleproofs/grand_prod.py
@@ -16,7 +16,6 @@ from curdleproofs.util import (
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
 from typing import List, Optional, Tuple, TypeVar, Type
 from curdleproofs.util import (
-    PointAffine,
     PointProjective,
     Fr,
     field_to_bytes,

--- a/curdleproofs/curdleproofs/ipa.py
+++ b/curdleproofs/curdleproofs/ipa.py
@@ -17,7 +17,6 @@ from curdleproofs.util import (
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
 from typing import List, Optional, Tuple, Type, TypeVar
 from curdleproofs.util import (
-    PointAffine,
     PointProjective,
     Fr,
     field_to_bytes,

--- a/curdleproofs/curdleproofs/msm_accumulator.py
+++ b/curdleproofs/curdleproofs/msm_accumulator.py
@@ -1,5 +1,5 @@
 import random
-from curdleproofs.util import PointAffine, PointProjective, Fr, affine_to_projective
+from curdleproofs.util import PointProjective, Fr, affine_to_projective
 from typing import Dict, List, Tuple, Union
 from py_ecc.optimized_bls12_381.optimized_curve import (
     curve_order,

--- a/curdleproofs/curdleproofs/opening.py
+++ b/curdleproofs/curdleproofs/opening.py
@@ -54,7 +54,7 @@ class TrackerOpeningProof:
 
         transcript.append_list(
             b"tracker_opening_proof",
-            points_projective_to_bytes([k_G, G, k_r_G, r_G, A, B]),
+            points_projective_to_bytes([k_G, G1, k_r_G, r_G, A, B]),
         )
 
         challenge = transcript.get_and_append_challenge(

--- a/curdleproofs/curdleproofs/same_msm.py
+++ b/curdleproofs/curdleproofs/same_msm.py
@@ -17,7 +17,7 @@ from curdleproofs.util import (
 )
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
 from typing import List, Optional, Tuple, Type, TypeVar
-from curdleproofs.util import PointAffine, PointProjective, Fr, field_to_bytes, invert
+from curdleproofs.util import PointProjective, Fr, field_to_bytes, invert
 from curdleproofs.msm_accumulator import MSMAccumulator, compute_MSM
 from py_ecc.optimized_bls12_381.optimized_curve import (
     curve_order,

--- a/curdleproofs/curdleproofs/same_perm.py
+++ b/curdleproofs/curdleproofs/same_perm.py
@@ -7,7 +7,6 @@ from curdleproofs.ipa import generate_blinders
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
 from typing import List, Optional, Tuple, Type, TypeVar
 from curdleproofs.util import (
-    PointAffine,
     PointProjective,
     Fr,
     field_to_bytes,

--- a/curdleproofs/curdleproofs/same_scalar.py
+++ b/curdleproofs/curdleproofs/same_scalar.py
@@ -6,7 +6,6 @@ from curdleproofs.util import field_from_json, field_to_json, points_projective_
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
 from typing import List, Tuple, Type, TypeVar
 from curdleproofs.util import (
-    PointAffine,
     PointProjective,
     Fr,
     field_to_bytes,

--- a/curdleproofs/curdleproofs/test_curdleproofs.py
+++ b/curdleproofs/curdleproofs/test_curdleproofs.py
@@ -17,7 +17,6 @@ from curdleproofs.util import (
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
 from typing import List, Optional, Tuple, Type, TypeVar
 from curdleproofs.util import (
-    PointAffine,
     PointProjective,
     Fr,
     field_to_bytes,
@@ -31,7 +30,6 @@ from py_ecc.optimized_bls12_381.optimized_curve import (
     curve_order,
     G1,
     multiply,
-    normalize,
     add,
     neg,
     Z1,
@@ -436,8 +434,8 @@ def test_shuffle_argument():
     random.shuffle(permutation)
     k = Fr(random.randint(1, Fr.field_modulus))
 
-    vec_R = [normalize(get_random_point()) for _ in range(ell)]
-    vec_S = [normalize(get_random_point()) for _ in range(ell)]
+    vec_R = [get_random_point() for _ in range(ell)]
+    vec_S = [get_random_point() for _ in range(ell)]
 
     vec_T, vec_U, M, vec_m_blinders = shuffle_permute_and_commit_input(
         crs, vec_R, vec_S, permutation, k
@@ -475,8 +473,8 @@ def test_bad_shuffle_argument():
     random.shuffle(permutation)
     k = Fr(random.randint(1, Fr.field_modulus))
 
-    vec_R = [normalize(get_random_point()) for _ in range(ell)]
-    vec_S = [normalize(get_random_point()) for _ in range(ell)]
+    vec_R = [get_random_point() for _ in range(ell)]
+    vec_S = [get_random_point() for _ in range(ell)]
 
     vec_T, vec_U, M, vec_m_blinders = shuffle_permute_and_commit_input(
         crs, vec_R, vec_S, permutation, k
@@ -524,12 +522,8 @@ def test_bad_shuffle_argument():
     assert not verify
 
     another_k = Fr(random.randint(1, Fr.field_modulus))
-    another_vec_T = [
-        normalize(multiply(affine_to_projective(T), int(another_k))) for T in vec_T
-    ]
-    another_vec_U = [
-        normalize(multiply(affine_to_projective(U), int(another_k))) for U in vec_U
-    ]
+    another_vec_T = [multiply(affine_to_projective(T), int(another_k)) for T in vec_T]
+    another_vec_U = [multiply(affine_to_projective(U), int(another_k)) for U in vec_U]
 
     verify, err = shuffle_proof.verify(
         crs, vec_R, vec_S, another_vec_T, another_vec_U, M
@@ -549,8 +543,8 @@ def test_serde():
     random.shuffle(permutation)
     k = Fr(random.randint(1, Fr.field_modulus))
 
-    vec_R = [normalize(get_random_point()) for _ in range(ell)]
-    vec_S = [normalize(get_random_point()) for _ in range(ell)]
+    vec_R = [get_random_point() for _ in range(ell)]
+    vec_S = [get_random_point() for _ in range(ell)]
 
     vec_T, vec_U, M, vec_m_blinders = shuffle_permute_and_commit_input(
         crs, vec_R, vec_S, permutation, k
@@ -651,15 +645,15 @@ def generate_random_k() -> Fr:
     return generate_blinders(1)[0]
 
 
-def get_k_commitment(k: Fr) -> PointAffine:
-    return normalize(multiply(G1, int(k)))
+def get_k_commitment(k: Fr) -> PointProjective:
+    return multiply(G1, int(k))
 
 
 def generate_tracker(k: Fr) -> WhiskTracker:
     r = generate_blinders(1)[0]
     r_G = multiply(G1, int(r))
     k_r_G = multiply(r_G, int(k))
-    return WhiskTracker(normalize(r_G), normalize(k_r_G))
+    return WhiskTracker(r_G, k_r_G)
 
 
 def generate_random_crs(ell: int) -> CurdleproofsCrs:

--- a/curdleproofs/curdleproofs/whisk_interface.py
+++ b/curdleproofs/curdleproofs/whisk_interface.py
@@ -21,10 +21,10 @@ from py_ecc.optimized_bls12_381.optimized_curve import G1, normalize, multiply
 
 
 class WhiskTracker:
-    r_G: BLSG1Point  # r * G
-    k_r_G: BLSG1Point  # k * r * G
+    r_G: PointProjective  # r * G
+    k_r_G: PointProjective  # k * r * G
 
-    def __init__(self, r_G: BLSG1Point, k_r_G: BLSG1Point):
+    def __init__(self, r_G: PointProjective, k_r_G: PointProjective):
         self.r_G = r_G
         self.k_r_G = k_r_G
 
@@ -112,7 +112,7 @@ SerializedWhiskTrackerProof = bytes
 
 def IsValidWhiskOpeningProof(
     tracker: WhiskTracker,
-    k_commitment: BLSG1Point,
+    k_commitment: PointProjective,
     tracker_proof: SerializedWhiskTrackerProof,
 ) -> bool:
     """
@@ -123,9 +123,9 @@ def IsValidWhiskOpeningProof(
     transcript_verifier = CurdleproofsTranscript(b"whisk_opening_proof")
     return tracker_proof_instance.verify(
         transcript_verifier,
-        affine_to_projective(tracker.k_r_G),
-        affine_to_projective(tracker.r_G),
-        affine_to_projective(k_commitment),
+        tracker.k_r_G,
+        tracker.r_G,
+        k_commitment,
     )
 
 
@@ -135,8 +135,8 @@ def GenerateWhiskTrackerProof(
 ) -> SerializedWhiskTrackerProof:
     transcript_prover = CurdleproofsTranscript(b"whisk_opening_proof")
     opening_proof = TrackerOpeningProof.new(
-        k_r_G=affine_to_projective(tracker.k_r_G),
-        r_G=affine_to_projective(tracker.r_G),
+        k_r_G=tracker.k_r_G,
+        r_G=tracker.r_G,
         k_G=multiply(G1, int(k)),
         G=G1,
         k=k,


### PR DESCRIPTION
I encountered many type bugs at runtime due to the mixed use of 2d and 3d form of points. Downstreams verifier consumers should mostly deal with compressed or serialized arguments. For generation using projective points is more convenient and less error prone.