### PR TITLE
Implement serde to bytes

### DIFF
--- a/curdleproofs/curdleproofs/commitment.py
+++ b/curdleproofs/curdleproofs/commitment.py
@@ -9,6 +9,9 @@ from curdleproofs.util import (
     get_random_point,
     point_projective_from_json,
     point_projective_to_json,
+    point_projective_to_bytes,
+    BufReader,
+    g1_to_bytes,
 )
 from py_ecc.optimized_bls12_381.optimized_curve import (
     curve_order,
@@ -69,4 +72,17 @@ class GroupCommitment:
         return cls(
             T_1=point_projective_from_json(json["T_1"]),
             T_2=point_projective_from_json(json["T_2"]),
+        )
+    
+    def to_bytes(self) -> bytes:
+        return b''.join([
+            g1_to_bytes(self.T_1),
+            g1_to_bytes(self.T_2),
+        ])
+    
+    @classmethod
+    def from_bytes(cls: Type[T_GroupCommitment], b: BufReader) -> T_GroupCommitment:
+        return cls(
+            T_1=b.read_g1(),
+            T_2=b.read_g1(),
         )

--- a/curdleproofs/curdleproofs/crs.py
+++ b/curdleproofs/curdleproofs/crs.py
@@ -16,7 +16,11 @@ from curdleproofs.util import (
     get_random_point,
     point_projective_from_json,
     point_projective_to_json,
+    BufReader,
+    g1_to_bytes,
 )
+from py_ecc.bls.g2_primitives import G1_to_pubkey, pubkey_to_G1
+from eth_typing import BLSPubkey
 
 T_CurdleproofsCrs = TypeVar("T_CurdleproofsCrs", bound="CurdleproofsCrs")
 
@@ -85,4 +89,27 @@ class CurdleproofsCrs:
             G_u=point_projective_from_json(dic["G_u"]),
             G_sum=point_projective_from_json(dic["G_sum"]),
             H_sum=point_projective_from_json(dic["H_sum"]),
+        )
+
+    def to_bytes(self) -> bytes:
+        return b''.join([
+            b''.join([g1_to_bytes(g) for g in self.vec_G]),
+            b''.join([g1_to_bytes(h) for h in self.vec_H]),
+            g1_to_bytes(self.H),
+            g1_to_bytes(self.G_t),
+            g1_to_bytes(self.G_u),
+            g1_to_bytes(self.G_sum),
+            g1_to_bytes(self.H_sum),
+        ])
+    
+    @classmethod
+    def from_bytes(cls: Type[T_CurdleproofsCrs], b: BufReader, ell: int, n_blinders: int) -> T_CurdleproofsCrs:
+        return cls(
+            vec_G=[b.read_g1() for _ in range(0, ell)],
+            vec_H=[b.read_g1() for _ in range(0, n_blinders)],
+            H=b.read_g1(),
+            G_t=b.read_g1(),
+            G_u=b.read_g1(),
+            G_sum=b.read_g1(),
+            H_sum=b.read_g1(),
         )

--- a/curdleproofs/curdleproofs/grand_prod.py
+++ b/curdleproofs/curdleproofs/grand_prod.py
@@ -12,6 +12,9 @@ from curdleproofs.util import (
     point_projective_to_bytes,
     get_random_point,
     point_projective_to_json,
+    BufReader,
+    g1_to_bytes,
+    fr_to_bytes,
 )
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
 from typing import List, Optional, Tuple, TypeVar, Type
@@ -220,4 +223,19 @@ class GrandProductProof:
             C=point_projective_from_json(json["C"]),
             r_p=field_from_json(json["r_p"], Fr),
             ipa_proof=IPA.from_json(json["ipa_proof"]),
+        )
+    
+    def to_bytes(self) -> bytes:
+        return b''.join([
+            g1_to_bytes(self.C),
+            fr_to_bytes(self.r_p),
+            self.ipa_proof.to_bytes(),
+        ])
+
+    @classmethod
+    def from_bytes(cls: Type[T_GrandProductProof], b: BufReader, n: int) -> T_GrandProductProof:
+        return cls(
+            C=b.read_g1(),
+            r_p=b.read_fr(),
+            ipa_proof=IPA.from_bytes(b, n),
         )

--- a/curdleproofs/curdleproofs/ipa.py
+++ b/curdleproofs/curdleproofs/ipa.py
@@ -13,6 +13,11 @@ from curdleproofs.util import (
     points_affine_to_bytes,
     points_projective_to_bytes,
     get_random_point,
+    BufReader,
+    g1_to_bytes,
+    fr_to_bytes,
+    g1_list_to_bytes,
+    log2_int,
 )
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
 from typing import List, Optional, Tuple, Type, TypeVar
@@ -283,4 +288,30 @@ class IPA:
             vec_R_D=[point_projective_from_json(p) for p in json["vec_R_D"]],
             c_final=field_from_json(json["c_final"], Fr),
             d_final=field_from_json(json["d_final"], Fr),
+        )
+    
+    def to_bytes(self) -> bytes:
+        return b''.join([
+            g1_to_bytes(self.B_c),
+            g1_to_bytes(self.B_d),
+            g1_list_to_bytes(self.vec_L_C),
+            g1_list_to_bytes(self.vec_R_C),
+            g1_list_to_bytes(self.vec_L_D),
+            g1_list_to_bytes(self.vec_R_D),
+            fr_to_bytes(self.c_final),
+            fr_to_bytes(self.d_final),
+        ])
+    
+    @classmethod
+    def from_bytes(cls: Type[T_IPA], b: BufReader, n: int) -> T_IPA:
+        log2_n = log2_int(n)
+        return cls(
+            B_c=b.read_g1(),
+            B_d=b.read_g1(),
+            vec_L_C=[b.read_g1() for _ in range(0, log2_n)],
+            vec_R_C=[b.read_g1() for _ in range(0, log2_n)],
+            vec_L_D=[b.read_g1() for _ in range(0, log2_n)],
+            vec_R_D=[b.read_g1() for _ in range(0, log2_n)],
+            c_final=b.read_fr(),
+            d_final=b.read_fr(),
         )

--- a/curdleproofs/curdleproofs/same_perm.py
+++ b/curdleproofs/curdleproofs/same_perm.py
@@ -15,6 +15,8 @@ from curdleproofs.util import (
     points_projective_to_bytes,
     get_random_point,
     get_permutation,
+    BufReader,
+    g1_to_bytes,
 )
 from curdleproofs.msm_accumulator import MSMAccumulator, compute_MSM
 from py_ecc.optimized_bls12_381.optimized_curve import (
@@ -27,6 +29,8 @@ from py_ecc.optimized_bls12_381.optimized_curve import (
     Z1,
 )
 from operator import mul as op_mul
+from py_ecc.bls.g2_primitives import G1_to_pubkey, pubkey_to_G1
+from eth_typing import BLSPubkey
 
 T_SAME_PERM_PROOF = TypeVar("T_SAME_PERM_PROOF", bound="SamePermutationProof")
 
@@ -153,4 +157,17 @@ class SamePermutationProof:
         return cls(
             B=point_projective_from_json(json["B"]),
             grand_prod_proof=GrandProductProof.from_json(json["grand_prod_proof"]),
+        )
+    
+    def to_bytes(self) -> bytes:
+        return b''.join([
+            g1_to_bytes(self.B),
+            self.grand_prod_proof.to_bytes(),
+        ])
+
+    @classmethod
+    def from_bytes(cls: Type[T_SAME_PERM_PROOF], b: BufReader, n: int) -> T_SAME_PERM_PROOF:
+        return cls(
+            B=b.read_g1(),
+            grand_prod_proof=GrandProductProof.from_bytes(b, n),
         )

--- a/curdleproofs/curdleproofs/same_scalar.py
+++ b/curdleproofs/curdleproofs/same_scalar.py
@@ -10,6 +10,10 @@ from curdleproofs.util import (
     Fr,
     field_to_bytes,
     get_random_point,
+    g1_from_bytes,
+    BufReader,
+    g1_to_bytes,
+    fr_to_bytes,
 )
 from curdleproofs.msm_accumulator import MSMAccumulator
 from py_ecc.optimized_bls12_381.optimized_curve import (
@@ -21,6 +25,8 @@ from py_ecc.optimized_bls12_381.optimized_curve import (
     neg,
 )
 from operator import mul as op_mul
+from py_ecc.bls.g2_primitives import G1_to_pubkey, pubkey_to_G1
+from eth_typing import BLSPubkey
 
 T_SameScalarProof = TypeVar("T_SameScalarProof", bound="SameScalarProof")
 
@@ -145,3 +151,23 @@ class SameScalarProof:
             z_t=field_from_json(json["z_t"], Fr),
             z_u=field_from_json(json["z_u"], Fr),
         )
+    
+    def to_bytes(self) -> bytes:
+        return b''.join([
+            self.cm_A.to_bytes(),
+            self.cm_B.to_bytes(),
+            fr_to_bytes(self.z_k),
+            fr_to_bytes(self.z_t),
+            fr_to_bytes(self.z_u),
+        ])
+
+    @classmethod
+    def from_bytes(cls: Type[T_SameScalarProof], b: BufReader) -> T_SameScalarProof:
+        return cls(
+            cm_A=GroupCommitment.from_bytes(b),
+            cm_B=GroupCommitment.from_bytes(b),
+            z_k=b.read_fr(),
+            z_t=b.read_fr(),
+            z_u=b.read_fr(),
+        )
+

--- a/curdleproofs/curdleproofs/test_curdleproofs.py
+++ b/curdleproofs/curdleproofs/test_curdleproofs.py
@@ -34,6 +34,7 @@ from py_ecc.optimized_bls12_381.optimized_curve import (
     neg,
     Z1,
 )
+from py_ecc.bls.g2_primitives import G1_to_pubkey, pubkey_to_G1
 from curdleproofs.ipa import IPA
 from curdleproofs.same_perm import SamePermutationProof
 from curdleproofs.same_msm import SameMSMProof
@@ -52,7 +53,7 @@ from curdleproofs.whisk_interface import (
     IsValidWhiskOpeningProof,
     IsValidWhiskShuffleProof,
 )
-
+from eth_typing import BLSPubkey
 
 def test_ipa():
     transcript = CurdleproofsTranscript(b"curdleproofs")
@@ -610,7 +611,7 @@ def test_tracker_opening_proof():
 
     transcript_prover = CurdleproofsTranscript(b"whisk_opening_proof")
     opening_proof = TrackerOpeningProof.new(
-        k_r_G=k_r_G, r_G=r_G, k_G=k_G, G=G, k=k, transcript=transcript_prover
+        k_r_G=k_r_G, r_G=r_G, k_G=k_G, k=k, transcript=transcript_prover
     )
 
     json_str_proof = opening_proof.to_json()
@@ -645,15 +646,15 @@ def generate_random_k() -> Fr:
     return generate_blinders(1)[0]
 
 
-def get_k_commitment(k: Fr) -> PointProjective:
-    return multiply(G1, int(k))
+def get_k_commitment(k: Fr) -> BLSPubkey:
+    return G1_to_pubkey(multiply(G1, int(k)))
 
 
 def generate_tracker(k: Fr) -> WhiskTracker:
     r = generate_blinders(1)[0]
     r_G = multiply(G1, int(r))
     k_r_G = multiply(r_G, int(k))
-    return WhiskTracker(r_G, k_r_G)
+    return WhiskTracker(G1_to_pubkey(r_G), G1_to_pubkey(k_r_G))
 
 
 def generate_random_crs(ell: int) -> CurdleproofsCrs:

--- a/curdleproofs/curdleproofs/util.py
+++ b/curdleproofs/curdleproofs/util.py
@@ -1,4 +1,5 @@
 from random import randint
+from math import log2
 from typing import List, Tuple, Type, TypeVar, Union
 from py_ecc.typing import (
     Optimized_Field,
@@ -15,6 +16,10 @@ from py_ecc.optimized_bls12_381.optimized_curve import (
     neg,
     FQ,
 )
+from py_ecc.bls.hash import os2ip, i2osp
+from py_ecc.bls.g2_primitives import G1_to_pubkey, pubkey_to_G1
+from eth_typing import BLSPubkey
+from py_ecc.bls.point_compression import compress_G1
 
 
 class Fr(FQ_type):
@@ -51,6 +56,10 @@ def fields_to_bytes(fields: List[Fr]) -> List[bytes]:
 
 def affine_to_projective(point: PointAffine) -> PointProjective:
     return (point[0], point[1], FQ.one())
+
+
+def g1_from_bytes(b: bytes, offset_point: int) -> PointProjective:
+    return pubkey_to_G1(BLSPubkey(b[48 * offset_point:48 * (offset_point + 1)]))
 
 
 def invert(f: Fr) -> Fr:
@@ -117,3 +126,40 @@ def point_affine_from_json(t: Tuple[str, str]) -> PointAffine:
 
 def point_projective_from_json(t: Tuple[str, str]) -> PointProjective:
     return affine_to_projective(point_affine_from_json(t))
+
+
+def g1_to_bytes(p: PointProjective) -> bytes:
+    return compress_G1(p).to_bytes(48, 'big')
+
+
+def g1_list_to_bytes(ps: List[PointProjective]) -> bytes:
+    return b''.join([g1_to_bytes(p) for p in ps])
+
+
+def fr_to_bytes(fr: Fr) -> bytes:
+    return fr.n.to_bytes(48, "big")
+
+
+def log2_int(x: int) -> int:
+    lg_x = int(log2(x))
+    if x != 2**lg_x:
+        raise Exception("x not a power of 2", x)
+    return lg_x
+
+
+class BufReader:
+    def __init__(self, data):
+        self.data = data
+        self.ptr = 0
+
+    def read_g1(self) -> PointProjective:
+        end_ptr = self.ptr + 48
+        p = pubkey_to_G1(BLSPubkey(self.data[self.ptr:end_ptr]))
+        self.ptr = end_ptr
+        return p
+    
+    def read_fr(self) -> Fr:
+        end_ptr = self.ptr + 48
+        p = Fr(os2ip(self.data[self.ptr:end_ptr]))
+        self.ptr = end_ptr
+        return p


### PR DESCRIPTION
Add serialization and deserialization to bytes to have a format suitable for wire transmission. The format is just concatenate all points in the data structures in compressed form. The format is not self-describing and requires knowledge in advance of the N parameter. This format achieves the minimal size possible and is suitable for Ethereum beacon chain needs