### PR TITLE
Pull 32 bytes for challenges and change sampling mechanism

### DIFF
--- a/curdleproofs/curdleproofs/curdleproofs_transcript.py
+++ b/curdleproofs/curdleproofs/curdleproofs_transcript.py
@@ -16,8 +16,11 @@ class CurdleproofsTranscript(MerlinTranscript):
 
     def get_and_append_challenge(self, label: bytes) -> Fr:
         while True:
-            challenge_bytes = self.challenge_bytes(label, 255)
-            f = Fr(bytes_to_int(challenge_bytes))
+            challenge_bytes = self.challenge_bytes(label, 32)
+            challenge_int = bytes_to_int(challenge_bytes)
+            if challenge_int >= curve_order:
+                continue
+            f = Fr(challenge_int)
             if f != Fr.zero():
                 self.append(label, challenge_bytes)
                 return f


### PR DESCRIPTION
This PR modifies the way the transcript pulls bytes to generate challenges:
- Pull 32 bytes from the underlying STROBE entropy since it should be enough bytes for a field element. (The Rust implementation is pulling 64 bytes today, from what we discussed it will switch to 32 bytes in the near future).
- The "bytes to Fr" transformation should be canonical, or continue sampling until that happens. (i.e: don't do "modulo wrapping"). As a reference, [the Rust implementation](https://github.com/asn-d6/curdleproofs/blob/main/src/transcript.rs#L45) calls `from_random_bytes` which fails if the bytes "doesn't fit" a Fr.