### PR TITLE
Allow to create uncorrelated random CRS from seed

### DIFF
--- a/curdleproofs/curdleproofs/crs.py
+++ b/curdleproofs/curdleproofs/crs.py
@@ -5,6 +5,7 @@ from curdleproofs.util import (
     get_random_point,
     point_projective_from_json,
     point_projective_to_json,
+    point_from_seed,
     BufReader,
     g1_to_bytes,
     Z1
@@ -40,6 +41,12 @@ class CurdleproofsCrs:
     ) -> T_CurdleproofsCrs:
         count = ell + n_blinders + 3
         points: List[G1Point] = [get_random_point() for _ in range(0, count)]
+        return cls.from_random_points(ell, n_blinders, points)
+
+    @classmethod
+    def from_seed(cls: Type[T_CurdleproofsCrs], ell: int, n_blinders: int, seed: str) -> T_CurdleproofsCrs:
+        count = ell + n_blinders + 3
+        points = [point_from_seed(seed, i) for i in range(0, count)]
         return cls.from_random_points(ell, n_blinders, points)
 
     @classmethod

--- a/curdleproofs/curdleproofs/test_curdleproofs.py
+++ b/curdleproofs/curdleproofs/test_curdleproofs.py
@@ -727,6 +727,13 @@ def test_serde():
     )
 
 
+def test_crs_from_seed():
+    N = 64
+    ell = N - N_BLINDERS
+    crs = CurdleproofsCrs.from_seed(ell, N_BLINDERS, 'some_readable_seed')
+    print(crs.to_json())
+
+
 def test_tracker_opening_proof():
     G = G1
     k = generate_blinders(1)[0]

--- a/curdleproofs/curdleproofs/util.py
+++ b/curdleproofs/curdleproofs/util.py
@@ -1,4 +1,5 @@
 from random import randint
+import hashlib
 from math import log2
 from typing import List, TypeVar, NewType
 from py_arkworks_bls12381 import G1Point, Scalar
@@ -22,6 +23,14 @@ def random_scalar() -> Scalar:
     # Note: the constructor 'Scalar()' errors with integers of more than 128 bits
     # Scalar.from_le_bytes() requires integers less than  CURVE_ORDER
     return Scalar.from_le_bytes(randint(1, CURVE_ORDER - 1).to_bytes(32, 'little'))
+
+
+def point_from_seed(seed: str, nonce: int) -> G1Point:
+    message = seed + str(nonce)
+    hash_bytes = hashlib.sha256(message.encode()).digest()
+    hash_int = int.from_bytes(hash_bytes, byteorder='little')
+    k = Scalar.from_le_bytes((hash_int % CURVE_ORDER).to_bytes(32, 'little'))
+    return G1 * k
 
 
 def point_projective_to_bytes(point: G1Point) -> bytes:


### PR DESCRIPTION
> The right way to get the curdleproofs CRS is to use hash-to-group and hash some nothing-up-my-sleeve thing like "i am dapplion"

However py-arkworks-bls12381 does not expose hash-to-group AFAIK. Using the digest of a sha256 as Scalar * G1 = RandP be ok too?

Related GO code https://github.com/crate-crypto/go-ipa/blob/master/ipa/config.go#L177